### PR TITLE
This will fix the picture uploading

### DIFF
--- a/app/uploaders/picture_uploader.rb
+++ b/app/uploaders/picture_uploader.rb
@@ -6,7 +6,7 @@ class PictureUploader < CarrierWave::Uploader::Base
   # include CarrierWave::MiniMagick
 
   # Choose what kind of storage to use for this uploader:
-  storage :file
+  # storage :file
   # storage :fog
 
   # Override the directory where uploaded files will be stored.


### PR DESCRIPTION
Great pairing with you today. I figured out the issue we faced. Forgot to comment out the line

```ruby
storage :file
```

Without this line commented out we're still trying to write the file locally instead of using https://cloudinary.com/

If you merge this PR the repo should automatically deploy and you should be able to finally add the nine planets with images 😄 
